### PR TITLE
PMDのチェックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 モジュールの`build.gradle`に下記を追加します。
 
 ```groovy
-apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/1.2.0/ci.gradle"
+apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/1.1.0/ci.gradle"
 ```
 
 ## 拡張性

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 モジュールの`build.gradle`に下記を追加します。
 
 ```groovy
-apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/1.1.0/ci.gradle"
+apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/1.2.0/ci.gradle"
 ```
 
 ## 拡張性

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 モジュールの`build.gradle`に下記を追加します。
 
 ```groovy
-apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/1.0.0/ci.gradle"
+apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/1.1.0/ci.gradle"
 ```
 
 ## 拡張性

--- a/ci.gradle
+++ b/ci.gradle
@@ -5,10 +5,10 @@ apply plugin: 'checkstyle'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 
-check.dependsOn 'checkstyle', 'findbugs', 'pmd'
+check.dependsOn 'checkstyle', 'findbugs', 'pmd', 'cpd'
 
 def GIT_USER = 'monstar-lab'
-def CI_VERSION = '1.1.0'
+def CI_VERSION = '1.2.0'
 
 task checkstyle(type: Checkstyle) {
     def conf
@@ -84,6 +84,21 @@ task pmd(type: Pmd) {
         }
         html {
             destination "$project.buildDir/reports/pmd/pmd.html"
+        }
+    }
+}
+
+task cpd << {
+    File outDir = new File('build/reports/pmd/')
+    outDir.mkdirs()
+    ant.taskdef(name: 'cpd',
+            classname: 'net.sourceforge.pmd.cpd.CPDTask',
+            classpath: configurations.pmd.asPath)
+    ant.cpd(minimumTokenCount: '100',
+            format: 'xml',
+            outputFile: new File(outDir , 'cpd.xml')) {
+        fileset(dir: "src/main/java") {
+            include(name: '**/*.java')
         }
     }
 }

--- a/ci.gradle
+++ b/ci.gradle
@@ -89,7 +89,7 @@ task pmd(type: Pmd) {
 }
 
 task cpd << {
-    File outDir = new File('build/reports/pmd/')
+    File outDir = new File("$project.buildDir/reports/pmd/")
     outDir.mkdirs()
     ant.taskdef(name: 'cpd',
             classname: 'net.sourceforge.pmd.cpd.CPDTask',

--- a/ci.gradle
+++ b/ci.gradle
@@ -3,9 +3,11 @@
  */
 apply plugin: 'checkstyle'
 apply plugin: 'findbugs'
+apply plugin: 'pmd'
 
-check.dependsOn 'checkstyle', 'findbugs'
+check.dependsOn 'checkstyle', 'findbugs', 'pmd'
 
+def GIT_USER = 'monstar-lab'
 def CI_VERSION = '1.0.0'
 
 task checkstyle(type: Checkstyle) {
@@ -14,7 +16,7 @@ task checkstyle(type: Checkstyle) {
         conf = file(checkStyleConfigFile)
     } else {
         conf = File.createTempFile("checkstyle", "")
-        new URL("https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/$CI_VERSION/config/checkstyle/checkstyle.xml")
+        new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/checkstyle/checkstyle.xml")
                 .withInputStream{ i -> conf.withOutputStream{ it << i }}
     }
     configFile conf
@@ -36,7 +38,7 @@ task findbugs(type: FindBugs, dependsOn: assembleDebug) {
         conf = file(findBugsExcludeFilter)
     } else {
         conf = File.createTempFile("findbugs", "")
-        new URL("https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-check/$CI_VERSION/config/findbugs/findbugs-filter.xml")
+        new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/findbugs/findbugs-filter.xml")
                 .withInputStream{ i -> conf.withOutputStream{ it << i }}
     }
     excludeFilter = conf
@@ -54,4 +56,34 @@ task findbugs(type: FindBugs, dependsOn: assembleDebug) {
     }
 
     classpath = files()
+}
+
+task pmd(type: Pmd) {
+    ignoreFailures = true
+
+    def conf
+    if (project.hasProperty('pmdRuleSetFiles')) {
+        conf = file(pmdRuleSetFiles)
+    } else {
+        conf = File.createTempFile("pmd", "")
+        new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/pmd/pmd-ruleset.xml")
+                .withInputStream{ i -> conf.withOutputStream{ it << i }}
+    }
+    ruleSetFiles = conf
+    ruleSets = []
+
+    source 'src'
+    include '**/*.java'
+    exclude '**/gen/**'
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+        xml {
+            destination "$project.buildDir/reports/pmd/pmd.xml"
+        }
+        html {
+            destination "$project.buildDir/reports/pmd/pmd.html"
+        }
+    }
 }

--- a/ci.gradle
+++ b/ci.gradle
@@ -69,7 +69,7 @@ task pmd(type: Pmd) {
         new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/pmd/pmd-ruleset.xml")
                 .withInputStream{ i -> conf.withOutputStream{ it << i }}
     }
-    ruleSetFiles = conf
+    ruleSetFiles = files(conf)
     ruleSets = []
 
     source 'src'

--- a/ci.gradle
+++ b/ci.gradle
@@ -8,7 +8,7 @@ apply plugin: 'pmd'
 check.dependsOn 'checkstyle', 'findbugs', 'pmd'
 
 def GIT_USER = 'monstar-lab'
-def CI_VERSION = '1.0.0'
+def CI_VERSION = '1.1.0'
 
 task checkstyle(type: Checkstyle) {
     def conf

--- a/ci.gradle
+++ b/ci.gradle
@@ -8,7 +8,7 @@ apply plugin: 'pmd'
 check.dependsOn 'checkstyle', 'findbugs', 'pmd', 'cpd'
 
 def GIT_USER = 'monstar-lab'
-def CI_VERSION = '1.2.0'
+def CI_VERSION = '1.1.0'
 
 task checkstyle(type: Checkstyle) {
     def conf

--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -26,5 +26,7 @@
         <exclude name="ShortClassName" />
         <exclude name="VariableNamingConventions" />
     </rule>
-    <rule ref="rulesets/java/strings.xml" />
+    <rule ref="rulesets/java/strings.xml" >
+        <exclude name="AppendCharacterWithChar" />
+    </rule>
 </ruleset>

--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="Monstar Lab Android rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>Monstar Lab Android rules</description>
+
+    <exclude-pattern>.*/R.java</exclude-pattern>
+    <exclude-pattern>.*/gen/.*</exclude-pattern>
+
+    <rule ref="rulesets/java/android.xml" />
+    <rule ref="rulesets/java/basic.xml" >
+        <exclude name="CollapsibleIfStatements" />
+    </rule>
+    <rule ref="rulesets/java/braces.xml" />
+    <rule ref="rulesets/java/clone.xml" />
+    <rule ref="rulesets/java/finalizers.xml" />
+    <rule ref="rulesets/java/imports.xml" />
+    <rule ref="rulesets/java/logging-java.xml" />
+    <rule ref="rulesets/java/naming.xml">
+        <exclude name="AbstractNaming" />
+        <exclude name="LongVariable" />
+        <exclude name="ShortMethodName" />
+        <exclude name="ShortVariable" />
+        <exclude name="ShortClassName" />
+        <exclude name="VariableNamingConventions" />
+    </rule>
+    <rule ref="rulesets/java/strings.xml" />
+</ruleset>


### PR DESCRIPTION
他のタスクを真似て、PMDのチェックを追加しました。
チェックツールについては、実際の2案件にかけてみて、不要そうなものをexcludeしてあります。

自分のプロジェクトで試す場合は、

```
apply from: "https://raw.githubusercontent.com/noboru-i/gradle-android-ci-check/add-cpd-test/ci.gradle"
```

のように変更し、`./gradlew app:check`などと実行してみてください。
`app/build/reports/pmd/pmd.html`, `cpd.xml` のように作成されます。

ルールの詳細は
http://pmd.sourceforge.net/pmd-5.1.1/rules/index.html
