### PR TITLE
Add detekt for kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,8 @@ apply from: "https://raw.githubusercontent.com/monstar-lab/gradle-android-ci-che
 ```
 checkStyleConfigFile=../config/quality/checkstyle/checkstyle.xml
 findBugsExcludeFilter=../config/quality/findbugs/findbugs-filter.xml
+detektConfigFile=../config/quality/findbugs/detekt.yml
+
+#Default java(java and/or kotlin)
+lang=kotlin,java
 ```

--- a/ci-java.gradle
+++ b/ci-java.gradle
@@ -1,0 +1,101 @@
+/*
+ * for ci
+ */
+apply plugin: 'checkstyle'
+apply plugin: 'findbugs'
+apply plugin: 'pmd'
+
+check.dependsOn 'checkstyle', 'findbugs', 'pmd', 'cpd'
+
+task checkstyle(type: Checkstyle) {
+    def conf
+    if (project.hasProperty('checkStyleConfigFile')) {
+        conf = file(checkStyleConfigFile)
+    } else {
+        conf = File.createTempFile("checkstyle", "")
+        new URL("https://raw.githubusercontent.com/$gitUser/gradle-android-ci-check/$ciVersion/config/checkstyle/checkstyle.xml")
+                .withInputStream{ i -> conf.withOutputStream{ it << i }}
+    }
+    configFile conf
+    source 'src'
+    include '**/*.java'
+    exclude '**/gen/**'
+
+    classpath = files()
+    ignoreFailures = true
+}
+
+task findbugs(type: FindBugs, dependsOn: "assembleDebug") {
+    ignoreFailures = true
+    effort = "max"
+    reportLevel = "high"
+
+    def conf
+    if (project.hasProperty('findBugsExcludeFilter')) {
+        conf = file(findBugsExcludeFilter)
+    } else {
+        conf = File.createTempFile("findbugs", "")
+        new URL("https://raw.githubusercontent.com/$gitUser/gradle-android-ci-check/$ciVersion/config/findbugs/findbugs-filter.xml")
+                .withInputStream{ i -> conf.withOutputStream{ it << i }}
+    }
+    excludeFilter = conf
+    classes = files("$project.buildDir/intermediates/classes/")
+
+    source 'src'
+    include '**/*.java'
+    exclude '**/gen/**'
+
+    reports {
+        xml {
+            destination "$project.buildDir/reports/findbugs/findbugs.xml"
+            xml.withMessages true
+        }
+    }
+
+    classpath = files()
+}
+
+task pmd(type: Pmd) {
+    ignoreFailures = true
+
+    def conf
+    if (project.hasProperty('pmdRuleSetFiles')) {
+        conf = file(pmdRuleSetFiles)
+    } else {
+        conf = File.createTempFile("pmd", "")
+        new URL("https://raw.githubusercontent.com/$gitUser/gradle-android-ci-check/$ciVersion/config/pmd/pmd-ruleset.xml")
+                .withInputStream{ i -> conf.withOutputStream{ it << i }}
+    }
+    ruleSetFiles = files(conf)
+    ruleSets = []
+
+    source 'src'
+    include '**/*.java'
+    exclude '**/gen/**'
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+        xml {
+            destination "$project.buildDir/reports/pmd/pmd.xml"
+        }
+        html {
+            destination "$project.buildDir/reports/pmd/pmd.html"
+        }
+    }
+}
+
+task cpd << {
+    File outDir = new File("$project.buildDir/reports/pmd/")
+    outDir.mkdirs()
+    ant.taskdef(name: 'cpd',
+            classname: 'net.sourceforge.pmd.cpd.CPDTask',
+            classpath: configurations.pmd.asPath)
+    ant.cpd(minimumTokenCount: '100',
+            format: 'xml',
+            outputFile: new File(outDir , 'cpd.xml')) {
+        fileset(dir: "src/main/java") {
+            include(name: '**/*.java')
+        }
+    }
+}

--- a/ci-kotlin.gradle
+++ b/ci-kotlin.gradle
@@ -1,0 +1,30 @@
+check.dependsOn 'detekt'
+configurations {
+    detekt
+}
+
+dependencies {
+    detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.0.0.RC4-2'
+    detekt 'io.gitlab.arturbosch.detekt:detekt-formatting:1.0.0.RC4-2'
+}
+
+task detekt(type: JavaExec) {
+    def conf
+    println gitUser
+    if (project.hasProperty('detektConfigFile')) {
+        conf = file(detektConfigFile)
+    } else {
+        conf = File.createTempFile("detekt", ".yml")
+        new URL("https://raw.githubusercontent.com/$gitUser/gradle-android-ci-check/$ciVersion/config/detekt/detekt.yml")
+                .withInputStream{ i -> conf.withOutputStream{ it << i }}
+    }
+
+    main = "io.gitlab.arturbosch.detekt.cli.Main"
+    classpath = configurations.detekt
+    def input = "$rootDir"
+    def config = conf
+    def output = "$projectDir/build/reports/detekt/"
+    def filters = "(?i).*src/.*test/.*"
+    def params = ['-i', input, '-c', config, '-f', filters, '-o', output]
+    args(params)
+}

--- a/ci.gradle
+++ b/ci.gradle
@@ -1,104 +1,24 @@
-/*
- * for ci
- */
-apply plugin: 'checkstyle'
-apply plugin: 'findbugs'
-apply plugin: 'pmd'
 
-check.dependsOn 'checkstyle', 'findbugs', 'pmd', 'cpd'
+def GIT_USER = 'tientun'
+def CI_VERSION = 'master'
 
-def GIT_USER = 'monstar-lab'
-def CI_VERSION = '1.3.0'
-
-task checkstyle(type: Checkstyle) {
-    def conf
-    if (project.hasProperty('checkStyleConfigFile')) {
-        conf = file(checkStyleConfigFile)
-    } else {
-        conf = File.createTempFile("checkstyle", "")
-        new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/checkstyle/checkstyle.xml")
-                .withInputStream{ i -> conf.withOutputStream{ it << i }}
-    }
-    configFile conf
-    source 'src'
-    include '**/*.java'
-    exclude '**/gen/**'
-
-    classpath = files()
-    ignoreFailures = true
+if (!project.hasProperty('gitUser')) {
+    ext.gitUser = GIT_USER
 }
 
-task findbugs(type: FindBugs, dependsOn: "assembleDebug") {
-    ignoreFailures = true
-    effort = "max"
-    reportLevel = "high"
-
-    def conf
-    if (project.hasProperty('findBugsExcludeFilter')) {
-        conf = file(findBugsExcludeFilter)
-    } else {
-        conf = File.createTempFile("findbugs", "")
-        new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/findbugs/findbugs-filter.xml")
-                .withInputStream{ i -> conf.withOutputStream{ it << i }}
-    }
-    excludeFilter = conf
-    classes = files("$project.buildDir/intermediates/classes/")
-
-    source 'src'
-    include '**/*.java'
-    exclude '**/gen/**'
-
-    reports {
-        xml {
-            destination "$project.buildDir/reports/findbugs/findbugs.xml"
-            xml.withMessages true
-        }
-    }
-
-    classpath = files()
+if (!project.hasProperty('ciVersion')) {
+    ext.ciVersion = CI_VERSION
 }
 
-task pmd(type: Pmd) {
-    ignoreFailures = true
-
-    def conf
-    if (project.hasProperty('pmdRuleSetFiles')) {
-        conf = file(pmdRuleSetFiles)
-    } else {
-        conf = File.createTempFile("pmd", "")
-        new URL("https://raw.githubusercontent.com/$GIT_USER/gradle-android-ci-check/$CI_VERSION/config/pmd/pmd-ruleset.xml")
-                .withInputStream{ i -> conf.withOutputStream{ it << i }}
-    }
-    ruleSetFiles = files(conf)
-    ruleSets = []
-
-    source 'src'
-    include '**/*.java'
-    exclude '**/gen/**'
-
-    reports {
-        xml.enabled = true
-        html.enabled = true
-        xml {
-            destination "$project.buildDir/reports/pmd/pmd.xml"
-        }
-        html {
-            destination "$project.buildDir/reports/pmd/pmd.html"
-        }
-    }
+def languages = ["java"] //["java", "kotlin"]
+if (project.hasProperty('lang')) {
+    languages = lang.split(',')
 }
 
-task cpd << {
-    File outDir = new File("$project.buildDir/reports/pmd/")
-    outDir.mkdirs()
-    ant.taskdef(name: 'cpd',
-            classname: 'net.sourceforge.pmd.cpd.CPDTask',
-            classpath: configurations.pmd.asPath)
-    ant.cpd(minimumTokenCount: '100',
-            format: 'xml',
-            outputFile: new File(outDir , 'cpd.xml')) {
-        fileset(dir: "src/main/java") {
-            include(name: '**/*.java')
+languages.each {
+        if (it.equalsIgnoreCase("java")) {
+            apply from: "https://raw.githubusercontent.com/$gitUser/gradle-android-ci-check/$ciVersion/ci-java.gradle"
+        }else if(it.equalsIgnoreCase("kotlin")){
+            apply from: "https://raw.githubusercontent.com/$gitUser/gradle-android-ci-check/$ciVersion/ci-kotlin.gradle"
         }
     }
-}

--- a/ci.gradle
+++ b/ci.gradle
@@ -1,6 +1,6 @@
 
-def GIT_USER = 'tientun'
-def CI_VERSION = 'master'
+def GIT_USER = 'monstar-lab'
+def CI_VERSION = 'master' //Newest version
 
 if (!project.hasProperty('gitUser')) {
     ext.gitUser = GIT_USER

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,95 @@
+complexity:
+  active: true
+  LongMethod:
+    threshold: 20
+  LongParameterList:
+    threshold: 5
+  LargeClass:
+    threshold: 150
+  ComplexMethod:
+    threshold: 10
+  TooManyFunctions:
+    threshold: 10
+  ComplexCondition:
+    threshold: 3
+
+style:
+  active: true
+  WildcardImport:
+    active: false
+  ModifierOrder:
+    active: true
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z$]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
+  FunctionNaming :
+    active: true
+    functionPattern: '^[a-z$][a-zA-Z$0-9]*$'
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 25
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  VariableNaming :
+    active: true
+    variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'
+  ConstantNaming :
+    active: true
+    constantPattern: '^([A-Z_]*|serialVersionUID)$'
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 17
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 3
+  MaxLineLength:
+    active: true
+    maxLineLength: 150
+    excludePackageStatements: false
+    excludeImportStatements: false
+  UnnecessaryParentheses:
+    active: false
+  ForbiddenComment:
+    active: false
+
+comments:
+  active: true
+  CommentOverPrivateMethod:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  NoDocOverPublicClass:
+    active: true
+  NoDocOverPublicMethod:
+    active: false
+  UndocumentedPublicFunction:
+    active: false
+
+potential-bugs:
+  active: true
+  DuplicateCaseInWhenExpression:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+  LateinitUsage:
+    active: false
+
+performance:
+  active: true
+  ForEachOnRange:
+    active: true
+
+exceptions:
+  active: true
+
+empty-blocks:
+  active: true


### PR DESCRIPTION
I added detekt and change something in ci.gradle to add option for switching configs file.
We can set variable in gradle.properties to check java(checkstyle, findbugs, pmd) or kotlin(detekt) or both of them(some project use both java and kotlin)

`lang=kotlin,java`